### PR TITLE
fix(sm): update naming rule with frigga

### DIFF
--- a/labels.tf
+++ b/labels.tf
@@ -1,18 +1,16 @@
-resource "random_string" "uid" {
-  length  = 12
-  upper   = false
-  lower   = true
-  number  = false
-  special = false
+### frigga name
+module "frigga" {
+  source  = "Young-ook/spinnaker/aws//modules/frigga"
+  version = "2.3.5"
+  name    = var.name == null || var.name == "" ? "sagemaker" : var.name
+  petname = var.name == null || var.name == "" ? true : false
 }
 
 locals {
-  service  = "sagemaker"
-  uid      = join("-", [local.service, random_string.uid.result])
-  name     = var.name == null ? local.uid : var.name
-  name-tag = { Name = format("%s", local.name) }
+  name = module.frigga.name
   default-tags = merge(
     { "terraform.io" = "managed" },
+    { "Name" = local.name },
   )
   sagemaker-shared-tag = {
     format("sagemaker/%s", local.name) = "shared"


### PR DESCRIPTION
This PR will clear following message.

```
Warning: Argument is deprecated
│ 
│   with module.sagemaker.random_string.uid,
│   on ../../labels.tf line 5, in resource "random_string" "uid":
│    5:   number  = false
│ 
│ Use numeric instead.
```